### PR TITLE
Fix uvloop installation issue on Windows

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -35,9 +35,10 @@ jobs:
 
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.9"]
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ To install the very latest from `main`:
 pip install git+https://github.com/stanfordnlp/dspy.git
 ````
 
+### Note for Windows Users
 
+The `uvloop` dependency is conditionally included for non-Windows platforms. If you encounter issues during installation, please ensure you are using a compatible platform or refer to the documentation for further assistance.
 
 
 ## 📜 Citation & Reading More

--- a/dspy/.internal_dspyai/setup.py
+++ b/dspy/.internal_dspyai/setup.py
@@ -19,5 +19,8 @@ setup(
     packages=find_packages(include=["dsp.*", "dspy.*", "dsp", "dspy"]),	
     python_requires=">=3.9",
     #replace_dspy_version_marker
-    install_requires=["dspy>=2.6.5"]
+    install_requires=[
+        "dspy>=2.6.5",
+        "uvloop; sys_platform != 'win32'"
+    ]
 )	

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "asyncer==0.0.8",
     "cachetools",
     "cloudpickle",
+    "uvloop; sys_platform != 'win32'",
 ]
 
 [tool.setuptools.packages.find]
@@ -144,6 +145,7 @@ tenacity = ">=8.2.3"
 asyncer = "0.0.8"
 cachetools = "^5.5.0"
 cloudpickle = "^3.0.0"
+uvloop = { version = "*", optional = true, markers = "sys_platform != 'win32'" }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"


### PR DESCRIPTION
Fix the RuntimeError caused by `uvloop` not supporting Windows during installation.

* **pyproject.toml**:
  - Add `uvloop` as a dependency only for non-Windows platforms.

* **dspy/.internal_dspyai/setup.py**:
  - Add `uvloop` as a dependency only for non-Windows platforms.

* **README.md**:
  - Add a note about the conditional inclusion of `uvloop` for Windows users.

* **.github/workflows/run_tests.yml**:
  - Update the workflow to run tests on multiple platforms (Ubuntu, Windows, macOS).

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chakravarthik27/dspy/pull/1?shareId=4866fc52-ae32-4b7f-89b3-4b0bd76b794e).